### PR TITLE
Mobile responsiveness for smartphone browsers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Playwright MCP output
+.playwright-mcp/

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Daniel Lofeodo</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/main.js
+++ b/main.js
@@ -61,6 +61,7 @@ controls.autoRotate = true;
 controls.autoRotateSpeed = 5;
 controls.enablePan = false;
 controls.enableZoom = false;
+controls.enabled = window.innerWidth > 768;
 
 // Resize
 window.addEventListener('resize', () => {
@@ -73,6 +74,8 @@ window.addEventListener('resize', () => {
   camera.updateProjectionMatrix();
   camera.aspect = sizes.width / sizes.height;
   renderer.setSize(sizes.width, sizes.height);
+
+  controls.enabled = window.innerWidth > 768;
 });
 
 // Dragging

--- a/style.css
+++ b/style.css
@@ -360,33 +360,40 @@ button{
     word-break: break-word;
   }
 
-  /* Hero takes less vertical space on mobile */
-  .hero {
-    min-height: 60vh;
-  }
-
   /* text-box is an unknown inline element — make it block so it constrains children */
   text-box {
     display: block;
   }
 
-  /* Hero */
+  /* Hero — full screen, content stretched top-to-bottom */
+  .hero {
+    align-items: stretch;
+  }
+
   .hero .content {
-    display: block;
-    padding: 40px 20px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-self: stretch;
+    padding: 40px 20px 50px;
+  }
+
+  #rollingHeroText {
+    font-size: clamp(1rem, 5vw, 1.4rem);
+    margin-bottom: 8px;
   }
 
   .hero .name {
-    font-size: clamp(1.5rem, 8vw, 2.5rem);
+    font-size: clamp(2rem, 11vw, 3.5rem);
     left: 0;
+    line-height: 1.1;
   }
 
-  /* Remove height: 100% so text flows directly under the name instead of anchoring to bottom */
   .hero .text {
     height: auto;
     align-items: flex-start;
     text-align: left;
-    margin-top: 20px;
+    margin-top: 0;
   }
 
   .hero .text span {

--- a/style.css
+++ b/style.css
@@ -351,3 +351,99 @@ button{
   transform: translateX(0);
   transform: translateY(0);
 }
+
+@media (max-width: 768px) {
+  /* Prevent grid items from overflowing their column */
+  .content {
+    min-width: 0;
+    overflow-wrap: break-word;
+    word-break: break-word;
+  }
+
+  /* Hero takes less vertical space on mobile */
+  .hero {
+    min-height: 60vh;
+  }
+
+  /* text-box is an unknown inline element — make it block so it constrains children */
+  text-box {
+    display: block;
+  }
+
+  /* Hero */
+  .hero .content {
+    display: block;
+    padding: 40px 20px;
+  }
+
+  .hero .name {
+    font-size: clamp(1.5rem, 8vw, 2.5rem);
+    left: 0;
+  }
+
+  /* Remove height: 100% so text flows directly under the name instead of anchoring to bottom */
+  .hero .text {
+    height: auto;
+    align-items: flex-start;
+    text-align: left;
+    margin-top: 20px;
+  }
+
+  .hero .text span {
+    padding: 3px 0;
+  }
+
+  .text {
+    font-size: clamp(0.875rem, 3.5vw, 1.2rem);
+  }
+
+  /* Nav — shrink buttons to fit three items */
+  button {
+    padding-right: 15px;
+    font-size: 0.82em;
+  }
+
+  /* Portfolio */
+  .image-w-text {
+    width: 95%;
+  }
+
+  .image-w-text img {
+    float: none;
+    max-width: 100%;
+    width: 100%;
+    margin: 0 0 12px 0;
+  }
+
+  .left-aligned text-box {
+    text-align: left;
+  }
+
+  /* About */
+  .about .content {
+    padding: 30px 20px;
+  }
+
+  .about .toolbelt li {
+    flex: 0 0 auto;
+  }
+
+  /* Contact */
+  .contact .content {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 2rem;
+    padding: 40px 20px;
+  }
+
+  .contact .email {
+    position: static;
+    top: auto;
+  }
+
+  .contact .email h1 {
+    font-size: clamp(0.85rem, 4vw, 1.5rem);
+    overflow-wrap: anywhere;
+  }
+}


### PR DESCRIPTION
## Summary

- Add missing `<meta name="viewport">` tag so mobile browsers render at device width instead of desktop scale
- Add `@media (max-width: 768px)` block covering all four sections: hero layout, portfolio image stacking, about text wrapping, contact email sizing
- Fix grid overflow (`min-width: 0` + `overflow-wrap` on `.content`; `display: block` on `<text-box>`) so text doesn't escape columns
- Rework hero for full 100vh on mobile: flex `space-between` spreads rolling subtitle to top, name to center, greeting to bottom; name scales to `11vw` for a clean two-line layout
- Disable `OrbitControls` touch handling on mobile so the sphere doesn't intercept scroll gestures
- Ignore `.playwright-mcp/` in `.gitignore`

## Test plan

- [ ] Load site on a 375px viewport (iPhone SE) — all four sections readable and usable
- [ ] Hero fills full screen height with subtitle at top, name centered, greeting at bottom
- [ ] Portfolio images stack full-width above their text descriptions
- [ ] About text wraps cleanly, toolbelt items wrap naturally
- [ ] Contact email fits on one line without overflow
- [ ] Scroll works on mobile (OrbitControls does not intercept touch)
- [ ] Desktop layout (1440px) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)