### PR TITLE
add squiggly vertical line animations on scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,5 +317,6 @@
       <script src="rollingText.js" type="module"></script>
       <script src="typeWriter.js" type="module"></script>
       <script src="scrollingEffects.js" type="module"></script>
+      <script src="squigglyLines.js" type="module"></script>
   </body>
 </html>

--- a/squigglyLines.js
+++ b/squigglyLines.js
@@ -1,0 +1,98 @@
+const CANVAS_WIDTH = 60;
+const MAX_AMP = 28;
+const FREQ = 0.018;
+const PHASE_SPEED = 0.035;
+
+const leftCanvas = document.createElement('canvas');
+const rightCanvas = document.createElement('canvas');
+
+for (const c of [leftCanvas, rightCanvas]) {
+  c.style.position = 'fixed';
+  c.style.top = '0';
+  c.style.width = CANVAS_WIDTH + 'px';
+  c.style.zIndex = '3';
+  c.style.pointerEvents = 'none';
+  document.body.appendChild(c);
+}
+
+let leftX = 0;
+let rightX = 0;
+
+function updatePositions() {
+  const topLeft = document.querySelector('.page .top-left');
+  const topRight = document.querySelector('.page .top-right');
+  if (!topLeft || !topRight) return;
+
+  const lRect = topLeft.getBoundingClientRect();
+  const rRect = topRight.getBoundingClientRect();
+  leftX = lRect.right;
+  rightX = rRect.left;
+
+  const dpr = window.devicePixelRatio || 1;
+  const h = window.innerHeight;
+
+  for (const c of [leftCanvas, rightCanvas]) {
+    c.width = CANVAS_WIDTH * dpr;
+    c.height = h * dpr;
+    c.style.height = h + 'px';
+  }
+
+  leftCanvas.style.left = (leftX - CANVAS_WIDTH / 2) + 'px';
+  rightCanvas.style.left = (rightX - CANVAS_WIDTH / 2) + 'px';
+}
+
+window.addEventListener('resize', updatePositions);
+window.addEventListener('load', updatePositions);
+updatePositions();
+
+let prevScrollY = window.scrollY;
+let scrollVelocity = 0;
+
+window.addEventListener('scroll', () => {
+  scrollVelocity = window.scrollY - prevScrollY;
+  prevScrollY = window.scrollY;
+}, { passive: true });
+
+let amplitude = 0;
+let phase = 0;
+
+function drawLine(ctx, canvasW, canvasH, amp, ph, direction) {
+  const dpr = window.devicePixelRatio || 1;
+  ctx.clearRect(0, 0, canvasW, canvasH);
+
+  ctx.fillStyle = 'black';
+  ctx.fillRect(0, 0, canvasW, canvasH);
+
+  const cx = (canvasW / 2);
+  ctx.beginPath();
+  ctx.strokeStyle = 'white';
+  ctx.lineWidth = 1.5 * dpr;
+  ctx.lineJoin = 'round';
+  ctx.lineCap = 'round';
+
+  for (let py = 0; py <= canvasH; py += 2) {
+    const x = cx + direction * amp * dpr * Math.sin(FREQ * (py / dpr) + ph);
+    if (py === 0) ctx.moveTo(x, py);
+    else ctx.lineTo(x, py);
+  }
+
+  ctx.stroke();
+}
+
+function animate() {
+  scrollVelocity *= 0.82;
+  const targetAmp = Math.min(Math.abs(scrollVelocity) * 1.8, MAX_AMP);
+  amplitude += (targetAmp - amplitude) * 0.12;
+  phase += PHASE_SPEED;
+
+  const dpr = window.devicePixelRatio || 1;
+  const lCtx = leftCanvas.getContext('2d');
+  const rCtx = rightCanvas.getContext('2d');
+
+  drawLine(lCtx, leftCanvas.width, leftCanvas.height, amplitude, phase, 1);
+  drawLine(rCtx, rightCanvas.width, rightCanvas.height, amplitude, phase, -1);
+
+  requestAnimationFrame(animate);
+}
+
+requestAnimationFrame(animate);

--- a/squigglyLines.js
+++ b/squigglyLines.js
@@ -1,7 +1,6 @@
 const CANVAS_WIDTH = 60;
 const MAX_AMP = 28;
 const FREQ = 0.018;
-const PHASE_SPEED = 0.035;
 
 const leftCanvas = document.createElement('canvas');
 const rightCanvas = document.createElement('canvas');
@@ -60,9 +59,6 @@ function drawLine(ctx, canvasW, canvasH, amp, ph, direction) {
   const dpr = window.devicePixelRatio || 1;
   ctx.clearRect(0, 0, canvasW, canvasH);
 
-  ctx.fillStyle = 'black';
-  ctx.fillRect(0, 0, canvasW, canvasH);
-
   const cx = (canvasW / 2);
   ctx.beginPath();
   ctx.strokeStyle = 'white';
@@ -83,7 +79,7 @@ function animate() {
   scrollVelocity *= 0.82;
   const targetAmp = Math.min(Math.abs(scrollVelocity) * 1.8, MAX_AMP);
   amplitude += (targetAmp - amplitude) * 0.12;
-  phase += PHASE_SPEED;
+  phase += 0.08 + amplitude * 0.008;
 
   const dpr = window.devicePixelRatio || 1;
   const lCtx = leftCanvas.getContext('2d');

--- a/style.css
+++ b/style.css
@@ -72,7 +72,8 @@ body{
 
   grid-template-columns: 1fr 8fr 1fr;
   grid-template-rows: auto 1fr;
-  gap: 1px;
+  row-gap: 1px;
+  column-gap: 0;
   border-bottom: 1px solid white;
 }
 


### PR DESCRIPTION
## Summary

- Two canvas elements replace the CSS column-gap vertical lines, animated with a physics-based sine wave driven by scroll velocity
- Amplitude scales with scroll speed (max 28px) and decays with momentum when scrolling stops — lines return to perfectly straight at rest
- Wave phase advances proportionally to amplitude so the wave visibly travels during scroll and slows to a subtle drift at rest
- Canvas background is transparent so the sphere, horizontal section lines, and marquees show through unobstructed

## Test plan

- [ ] Scroll slowly — lines squiggle with a gentle sine wave that travels along the line
- [ ] Scroll fast — bigger squiggles, faster wave propagation
- [ ] Stop scrolling — lines decay back to straight with momentum
- [ ] Confirm sphere, horizontal lines, and marquee text are not covered
- [ ] Resize window — lines reposition to stay at the grid column boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)