### PR TITLE
Sphere improvements: responsive sizing + z-index layering

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,9 +18,10 @@ const mesh = new THREE.Mesh(geometry, material);
 scene.add(mesh);
 
 // Sizes
+const sphereSize = () => Math.min(window.innerWidth / 3, window.innerHeight * 0.5);
 const sizes = {
-  width: window.innerWidth / 5,
-  height: window.innerWidth / 5
+  width: sphereSize(),
+  height: sphereSize()
 }
 
 // Light  
@@ -66,8 +67,8 @@ controls.enabled = window.innerWidth > 768;
 // Resize
 window.addEventListener('resize', () => {
   // Update sizes
-  sizes.width = window.innerWidth / 4;
-  sizes.height = window.innerWidth / 4;
+  sizes.width = sphereSize();
+  sizes.height = sphereSize();
   updateWebGlMargin();
 
   // Update camera

--- a/style.css
+++ b/style.css
@@ -23,6 +23,7 @@ body{
   margin: 0;
   max-width: 100%;
   height: auto;
+  background-color: black;
 
   font-family: 'Roboto Mono';
   scrollbar-width: thin; /* Firefox */
@@ -46,7 +47,7 @@ body{
 
 .grid > div > div {
   margin: 0;
-  background-color: black;
+  background-color: transparent;
   padding: 30px;
   height: 100%;
   width: 100%;
@@ -60,7 +61,7 @@ body{
   height: auto;
 
   margin: 0;
-  background: white;
+  background: transparent;
 }
 
 .page{
@@ -264,6 +265,8 @@ body{
 .content
 {
   grid-area: 2 / 2 / 2 / 2;
+  position: relative;
+  z-index: 2;
 }
 
 .navigation{


### PR DESCRIPTION
## Summary
- Sphere size is now `min(33% viewport width, 50% viewport height)` — stays proportional on landscape and portrait, and resizes correctly on window resize
- Black background moved to `body`; grid and section divs made transparent so the sphere is visible above the background throughout all sections
- `.content` gets `position: relative; z-index: 2` so section text renders in front of the sphere canvas

## Test plan
- [ ] Load site on a wide landscape screen — sphere fills top-right corner at ~33% width
- [ ] Resize to portrait — sphere shrinks to 50% height constraint
- [ ] Scroll through all sections — sphere visible through backgrounds, text readable on top
- [ ] Marquee banners and horizontal lines remain visually positioned relative to sphere as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)