### PR TITLE
Fixed header with marquee, D logo, z-index stack

### DIFF
--- a/fixedHeader.js
+++ b/fixedHeader.js
@@ -52,9 +52,9 @@ function crossfadeMarquee(newMarqueeId) {
   fixedMarquee.style.opacity = '0';
   fixedMarquee.offsetHeight; // force reflow
   loadMarqueeContent(newMarqueeId);
-  fixedMarquee.style.transition = 'opacity 0.25s ease';
+  fixedMarquee.style.transition = 'opacity 0.5s ease';
   fixedMarquee.style.opacity = '1';
-  crossfadeTimer = setTimeout(() => { crossfadeTimer = null; }, 250);
+  crossfadeTimer = setTimeout(() => { crossfadeTimer = null; }, 500);
 }
 
 function updateFixedHeader() {

--- a/fixedHeader.js
+++ b/fixedHeader.js
@@ -1,0 +1,95 @@
+const header = document.getElementById('fixedHeader');
+const headerBg = document.getElementById('fixedHeaderBg');
+const fixedMarquee = document.getElementById('fixedMarquee');
+const navSpacer = document.getElementById('fixedNavSpacer');
+
+function syncHeaderDimensions() {
+  const h = header.offsetHeight;
+  document.documentElement.style.setProperty('--fixed-header-height', h + 'px');
+  headerBg.style.height = h + 'px';
+}
+
+function updateNavOffset() {
+  const topLeft = document.querySelector('.page .top-left');
+  if (topLeft) {
+    navSpacer.style.width = topLeft.getBoundingClientRect().right + 'px';
+  }
+}
+
+syncHeaderDimensions();
+updateNavOffset();
+window.addEventListener('load', () => { syncHeaderDimensions(); updateNavOffset(); });
+
+const sections = [
+  { sectionId: 'portfolioID', marqueeId: 'portfolioMarquee' },
+  { sectionId: 'aboutID',     marqueeId: 'aboutMarquee'     },
+  { sectionId: 'contactID',   marqueeId: 'contactMarquee'   },
+];
+
+let activeMarqueeId = null;
+let displayedMarqueeId = null;
+let crossfadeTimer = null;
+
+function loadMarqueeContent(marqueeId) {
+  const src = document.getElementById(marqueeId);
+  fixedMarquee.innerHTML = src.innerHTML;
+  displayedMarqueeId = marqueeId;
+}
+
+function crossfadeMarquee(newMarqueeId) {
+  if (displayedMarqueeId === newMarqueeId) return;
+
+  if (crossfadeTimer) {
+    clearTimeout(crossfadeTimer);
+    crossfadeTimer = null;
+  }
+
+  fixedMarquee.style.transition = 'none';
+  fixedMarquee.style.opacity = '0';
+  fixedMarquee.offsetHeight; // force reflow
+  loadMarqueeContent(newMarqueeId);
+  fixedMarquee.style.transition = 'opacity 0.25s ease';
+  fixedMarquee.style.opacity = '1';
+  crossfadeTimer = setTimeout(() => { crossfadeTimer = null; }, 250);
+}
+
+function updateFixedHeader() {
+  const scrollY = window.scrollY;
+  const headerH = header.offsetHeight;
+
+  let currentSection = null;
+  for (const s of sections) {
+    const el = document.getElementById(s.sectionId);
+    if (scrollY + headerH >= el.offsetTop) currentSection = s;
+  }
+
+  if (currentSection) {
+    if (activeMarqueeId !== currentSection.marqueeId) {
+      activeMarqueeId = currentSection.marqueeId;
+      crossfadeMarquee(currentSection.marqueeId);
+    }
+    if (!crossfadeTimer) fixedMarquee.style.opacity = '1';
+  } else {
+    activeMarqueeId = null;
+    const portfolioEl = document.getElementById('portfolioID');
+    const transitionRange = 300;
+    const distanceToPortfolio = portfolioEl.offsetTop - headerH - scrollY;
+    const opacity = Math.max(0, 1 - distanceToPortfolio / transitionRange);
+
+    if (opacity > 0 && displayedMarqueeId !== 'portfolioMarquee') {
+      loadMarqueeContent('portfolioMarquee');
+    }
+    if (opacity === 0) displayedMarqueeId = null;
+
+    fixedMarquee.style.transition = 'none';
+    fixedMarquee.style.opacity = String(opacity);
+  }
+}
+
+window.addEventListener('scroll', updateFixedHeader, { passive: true });
+window.addEventListener('resize', () => {
+  syncHeaderDimensions();
+  updateNavOffset();
+  updateFixedHeader();
+});
+updateFixedHeader();

--- a/fixedHeader.js
+++ b/fixedHeader.js
@@ -7,6 +7,10 @@ function syncHeaderDimensions() {
   const h = header.offsetHeight;
   document.documentElement.style.setProperty('--fixed-header-height', h + 'px');
   headerBg.style.height = h + 'px';
+  const sampleMarquee = document.getElementById('portfolioMarquee');
+  if (sampleMarquee) {
+    document.documentElement.style.setProperty('--section-marquee-height', sampleMarquee.offsetHeight + 'px');
+  }
 }
 
 function updateNavOffset() {

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Roboto+Mono:ital,wght@0,100..700;1,100..700&family=Sixtyfour&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
+    <link rel="icon" href="/logo.svg" type="image/svg+xml">
   </head>
   <body>
     <div class="lineThroughSphere" id="heroLine"></div>
@@ -18,7 +19,11 @@
     <script type="module" src="/main.js"></script>
     <div id="fixedHeaderBg"></div>
     <div id="fixedHeader">
-      <div id="fixedNavSpacer"></div>
+      <div id="fixedNavSpacer">
+        <a id="logoLink" href="#" onclick="window.scrollTo({top:0,behavior:'smooth'});return false;" aria-label="Home">
+          <img src="/logo.svg" alt="D" width="36" height="36">
+        </a>
+      </div>
       <div class="navigation">
         <button onclick="scrollToSection('portfolioID')">Portfolio</button>
         <button onclick="scrollToSection('aboutID')">About</button>

--- a/index.html
+++ b/index.html
@@ -16,19 +16,26 @@
     <div class="lineThroughSphere" id="contactLine"></div>
     <canvas class="webgl"></canvas>
     <script type="module" src="/main.js"></script>
+    <div id="fixedHeaderBg"></div>
+    <div id="fixedHeader">
+      <div id="fixedNavSpacer"></div>
+      <div class="navigation">
+        <button onclick="scrollToSection('portfolioID')">Portfolio</button>
+        <button onclick="scrollToSection('aboutID')">About</button>
+        <button onclick="scrollToSection('contactID')">Contact</button>
+      </div>
+      <div id="fixedMarquee" class="marquee">
+        <div class="marquee-content scroll"></div>
+        <div class="marquee-content scroll"></div>
+      </div>
+    </div>
       <div class="grid">
           <div class="page hero" id="heroID">
               <div></div>
               <div></div>
               <div></div>
               <div></div>
-              <div class="titlebar">
-                  <div class="navigation">
-                      <button onclick="scrollToSection('portfolioID')">Portfolio</button>
-                      <button onclick="scrollToSection('aboutID')">About</button>
-                      <button onclick="scrollToSection('contactID')">Contact</button>
-                  </div>
-              </div>
+              <div class="titlebar"></div>
               <div class="content" id="heroContent">
                 <span id="rollingHeroText">M.Sc.Comp.Sci.</span>
                 <h1 class="name" id="name"></h1>
@@ -309,6 +316,7 @@
           </div>
       </div>
       <script src="scrollToFunction.js" type="module"></script>
+      <script src="fixedHeader.js" type="module"></script>
       <script src="sphereLines.js" type="module"></script>
       <script src="rollingText.js" type="module"></script>
       <script src="typeWriter.js" type="module"></script>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
                 <span id="rollingHeroText">M.Sc.Comp.Sci.</span>
                 <h1 class="name" id="name"></h1>
                 <div class="text">
-                    <span>Hello fellow nerd,</span>
+                    <span>Hello,</span>
                     <a
                         href="/cv.pdf"
                         target="_blank"

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" fill="#000"/>
+  <!-- Cyan shadow offset +1,+1 -->
+  <g fill="#0FF" opacity="0.75">
+    <rect x="7" y="5" width="4" height="4"/>
+    <rect x="11" y="5" width="4" height="4"/>
+    <rect x="15" y="5" width="4" height="4"/>
+    <rect x="7" y="9" width="4" height="4"/>
+    <rect x="19" y="9" width="4" height="4"/>
+    <rect x="7" y="13" width="4" height="4"/>
+    <rect x="23" y="13" width="4" height="4"/>
+    <rect x="7" y="17" width="4" height="4"/>
+    <rect x="23" y="17" width="4" height="4"/>
+    <rect x="7" y="21" width="4" height="4"/>
+    <rect x="19" y="21" width="4" height="4"/>
+    <rect x="7" y="25" width="4" height="4"/>
+    <rect x="11" y="25" width="4" height="4"/>
+    <rect x="15" y="25" width="4" height="4"/>
+  </g>
+  <!-- White D -->
+  <g fill="#FFF">
+    <rect x="6" y="4" width="4" height="4"/>
+    <rect x="10" y="4" width="4" height="4"/>
+    <rect x="14" y="4" width="4" height="4"/>
+    <rect x="6" y="8" width="4" height="4"/>
+    <rect x="18" y="8" width="4" height="4"/>
+    <rect x="6" y="12" width="4" height="4"/>
+    <rect x="22" y="12" width="4" height="4"/>
+    <rect x="6" y="16" width="4" height="4"/>
+    <rect x="22" y="16" width="4" height="4"/>
+    <rect x="6" y="20" width="4" height="4"/>
+    <rect x="18" y="20" width="4" height="4"/>
+    <rect x="6" y="24" width="4" height="4"/>
+    <rect x="10" y="24" width="4" height="4"/>
+    <rect x="14" y="24" width="4" height="4"/>
+  </g>
+  <!-- Subtle cyan border -->
+  <rect width="32" height="32" fill="none" stroke="#0FF" stroke-width="1" opacity="0.35"/>
+</svg>

--- a/sphereLines.js
+++ b/sphereLines.js
@@ -22,6 +22,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
 function updateLinePositions(){
     heroLine.style.position = 'fixed';
+    heroLine.style.zIndex = '2';
     heroLine.style.top = fixedHeaderEl.offsetHeight + 'px';
     aboutLine.style.top = aboutMarquee.offsetTop + aboutMarquee.offsetHeight + 'px';
     portfolioLine.style.top = portfolioMarquee.offsetTop + portfolioMarquee.offsetHeight + 'px';

--- a/sphereLines.js
+++ b/sphereLines.js
@@ -22,7 +22,6 @@ window.addEventListener('DOMContentLoaded', () => {
 
 function updateLinePositions(){
     heroLine.style.position = 'fixed';
-    heroLine.style.zIndex = '2';
     heroLine.style.top = fixedHeaderEl.offsetHeight + 'px';
     aboutLine.style.top = aboutMarquee.offsetTop + aboutMarquee.offsetHeight + 'px';
     portfolioLine.style.top = portfolioMarquee.offsetTop + portfolioMarquee.offsetHeight + 'px';

--- a/sphereLines.js
+++ b/sphereLines.js
@@ -3,10 +3,10 @@ const heroLine = document.getElementById('heroLine');
 const aboutLine = document.getElementById('aboutLine');
 const portfolioLine = document.getElementById('portfolioLine');
 const contactLine = document.getElementById('contactLine');
-const heroContent = document.getElementById('heroContent');
 const aboutMarquee = document.getElementById('aboutMarquee');
 const portfolioMarquee = document.getElementById('portfolioMarquee');
 const contactMarquee = document.getElementById('contactMarquee');
+const fixedHeaderEl = document.getElementById('fixedHeader');
 
 updateLinePositions();
 
@@ -21,7 +21,8 @@ window.addEventListener('DOMContentLoaded', () => {
 });
 
 function updateLinePositions(){
-    heroLine.style.top = heroContent.offsetTop - 1 + 'px';
+    heroLine.style.position = 'fixed';
+    heroLine.style.top = fixedHeaderEl.offsetHeight + 'px';
     aboutLine.style.top = aboutMarquee.offsetTop + aboutMarquee.offsetHeight + 'px';
     portfolioLine.style.top = portfolioMarquee.offsetTop + portfolioMarquee.offsetHeight + 'px';
     contactLine.style.top = contactMarquee.offsetTop + contactMarquee.offsetHeight + 'px';

--- a/squigglyLines.js
+++ b/squigglyLines.js
@@ -9,7 +9,7 @@ for (const c of [leftCanvas, rightCanvas]) {
   c.style.position = 'fixed';
   c.style.top = '0';
   c.style.width = CANVAS_WIDTH + 'px';
-  c.style.zIndex = '6';
+  c.style.zIndex = '7';
   c.style.pointerEvents = 'none';
   document.body.appendChild(c);
 }

--- a/squigglyLines.js
+++ b/squigglyLines.js
@@ -9,7 +9,7 @@ for (const c of [leftCanvas, rightCanvas]) {
   c.style.position = 'fixed';
   c.style.top = '0';
   c.style.width = CANVAS_WIDTH + 'px';
-  c.style.zIndex = '3';
+  c.style.zIndex = '6';
   c.style.pointerEvents = 'none';
   document.body.appendChild(c);
 }

--- a/squigglyLines.js
+++ b/squigglyLines.js
@@ -9,7 +9,7 @@ for (const c of [leftCanvas, rightCanvas]) {
   c.style.position = 'fixed';
   c.style.top = '0';
   c.style.width = CANVAS_WIDTH + 'px';
-  c.style.zIndex = '7';
+  c.style.zIndex = '8';
   c.style.pointerEvents = 'none';
   document.body.appendChild(c);
 }

--- a/style.css
+++ b/style.css
@@ -9,7 +9,7 @@
   position: fixed;
   top: var(--webGlMargin);
   right: var(--webGlMargin);
-  z-index: 5;
+  z-index: 4;
   cursor: grab;
 }
 
@@ -59,7 +59,7 @@ body{
   left: 0;
   right: 0;
   background: black;
-  z-index: 4;
+  z-index: 6;
 }
 
 #fixedHeader {
@@ -77,6 +77,15 @@ body{
 
 #fixedNavSpacer {
   flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+#logoLink {
+  display: flex;
+  cursor: pointer;
+  text-decoration: none;
 }
 
 #fixedHeader .navigation {
@@ -116,7 +125,7 @@ body{
 }
 
 .page.hero {
-  min-height: calc(100vh - var(--fixed-header-height, 0px));
+  min-height: calc(100vh - var(--fixed-header-height, 0px) - var(--section-marquee-height, 0px) - 5px);
 }
 
 .titlebar{
@@ -323,7 +332,7 @@ body{
 {
   grid-area: 2 / 2 / 2 / 2;
   position: relative;
-  z-index: 2;
+  z-index: 5;
 }
 
 .navigation{

--- a/style.css
+++ b/style.css
@@ -59,7 +59,7 @@ body{
   left: 0;
   right: 0;
   background: black;
-  z-index: 6;
+  z-index: 3;
 }
 
 #fixedHeader {
@@ -389,7 +389,7 @@ button{
 
 .lineThroughSphere{
   position: absolute;
-  z-index: 3;
+  z-index: 6;
   width: 100%;
   border-top: 5px solid white;
 }

--- a/style.css
+++ b/style.css
@@ -9,7 +9,7 @@
   position: fixed;
   top: var(--webGlMargin);
   right: var(--webGlMargin);
-  z-index: 1;
+  z-index: 5;
   cursor: grab;
 }
 
@@ -53,6 +53,43 @@ body{
   width: 100%;
 }
 
+#fixedHeaderBg {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  background: black;
+  z-index: 4;
+}
+
+#fixedHeader {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  font: 1em 'Sixtyfour';
+  padding: 30px 0;
+}
+
+#fixedNavSpacer {
+  flex-shrink: 0;
+}
+
+#fixedHeader .navigation {
+  padding-left: 30px;
+}
+
+#fixedMarquee {
+  flex: 1;
+  opacity: 0;
+  overflow: hidden;
+  position: relative;
+}
+
 .grid{
   display: grid;
   grid-template-columns: 1fr;
@@ -62,6 +99,7 @@ body{
 
   margin: 0;
   background: transparent;
+  padding-top: var(--fixed-header-height, 0px);
 }
 
 .page{
@@ -82,6 +120,10 @@ body{
   border-bottom: none;
 }
 
+.page.hero {
+  min-height: calc(100vh - var(--fixed-header-height, 0px));
+}
+
 .titlebar{
   font: 1em 'Sixtyfour';
   grid-area: 1 / 1 / 1 / 4;
@@ -96,7 +138,13 @@ body{
 }
 
 .hero .titlebar{
-  grid-area: 1 / 2 / 1 / 2;
+  display: none;
+}
+
+.portfolio .titlebar.marquee,
+.about .titlebar.marquee,
+.contact .titlebar.marquee {
+  visibility: hidden;
 }
 
 .hero .content{
@@ -337,7 +385,7 @@ button{
 
 .lineThroughSphere{
   position: absolute;
-  z-index: 2;
+  z-index: 3;
   width: 100%;
   border-top: 5px solid white;
 }

--- a/style.css
+++ b/style.css
@@ -113,11 +113,6 @@ body{
   grid-template-rows: auto 1fr;
   row-gap: 1px;
   column-gap: 0;
-  border-bottom: 1px solid white;
-}
-
-.contact{
-  border-bottom: none;
 }
 
 .page.hero {

--- a/style.css
+++ b/style.css
@@ -129,7 +129,7 @@ body{
 
 .about .titlebar, .portfolio .titlebar, .contact .titlebar{
   background-color: transparent;
-  padding: 50px 0px;
+  padding: 30px 0px;
 }
 
 .hero .titlebar{

--- a/style.css
+++ b/style.css
@@ -59,7 +59,7 @@ body{
   left: 0;
   right: 0;
   background: black;
-  z-index: 3;
+  z-index: 6;
 }
 
 #fixedHeader {

--- a/style.css
+++ b/style.css
@@ -9,7 +9,7 @@
   position: fixed;
   top: var(--webGlMargin);
   right: var(--webGlMargin);
-  z-index: 4;
+  z-index: 7;
   cursor: grab;
 }
 


### PR DESCRIPTION
@
## Summary
- Add fixed header with per-section scrolling marquee (PORTFOLIO / ABOUT / CONTACT)
- D pixel-art logo in header, doubles as favicon
- Hero height adjusted to sit flush with header bottom
- Squiggly column border lines, sphere, thick section dividers, and bg all in correct z-order:
  content(5) < bg=lines=6 < sphere(7) < squiggly(8) < nav(50)
- Marquee crossfade slowed to 500ms

## Test plan
- [ ] Hero renders at correct height (portfolioLine flush with viewport bottom)
- [ ] Sphere visible through header bg, in front of heroLine
- [ ] Thick section lines above thumbnail cards
- [ ] Nav text always readable above everything
- [ ] D logo links to top, renders as favicon

🤖 Generated with [Claude Code](https://claude.ai/claude-code)
@